### PR TITLE
Redirect from raje.html

### DIFF
--- a/raje.html
+++ b/raje.html
@@ -8,6 +8,10 @@
         <link rel="stylesheet" href="css/open-iconic.min.css" />
         <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.2/css/bootstrap.min.css" integrity="sha384-PsH8R72JQ3SOdhVi3uxftmaW6Vc51MKb0q5P2rRUpPvrszuE4W1povHYgTpBfshb"
     crossorigin="anonymous">
+        
+<meta http-equiv="refresh" content="0; URL=https://rash-framework.github.io/raje-app/">
+<link rel="canonical" href="https://rash-framework.github.io/raje-app/">        
+        
     </head>
     <body>
         <section class="first-panel">
@@ -27,62 +31,15 @@
                     </div>
                 </div>
             </nav>
-
-            <div class="jumbotron jumbotron-fluid text-center">
-                <div class="wrapper">
-                    <blockquote class="blockquote">
-                        <h1 class="mb-0 display-4 text-white"><b>RASH Javascript Editor (RAJE)</b></h1>
-                        <footer class="blockquote-footer">
-                            a Javascript-based wordprocessor for creating RASH documents natively
-                            <p>Main citation: Spinaci, G., Peroni, S., Di Iorio, A., Poggi, F., Vitali, F. (2017). The RASH JavaScript Editor (RAJE): A Wordprocessor for Writing Web-first Scholarly Articles. In Proceedings of the 2017 ACM Symposium on Document Engineering (DocEng 2017): 85-94. DOI: <a target="_blank" href="https://doi.org/10.1145/3103010.3103018">https://doi.org/10.1145/3103010.3103018</a> (also available in <a href="https://w3id.org/people/essepuntato/papers/raje-doceng2017.html">RASH</a>)</p>
-                        </footer>
-                    </blockquote>
-
-                    <div class="container">
-                        <a class="call_to_action" href="#a">XXX</a>
-                        <a class="call_to_action" href="#b">XXX</a>
-                        <a class="call_to_action" href="#c">XXX</a>
-                        <a class="call_to_action" href="#d">XXX</a>
-                        <a class="call_to_action" href="#e">XXX</a>
-                    </div>
-                </div>
-            </div>
         </section>
 
         <section id="a" class="third-panel">
             <div class="container">
-                <h1 class="display-4">Title</h1>
-                <p>XXX</p>
+                <h1 class="display-4">Moved</h1>
+                <p>This page has moved to <a href="https://rash-framework.github.io/raje-app/">https://rash-framework.github.io/raje-app/</a></p>
             </div>
         </section>
         
-        <section id="b" class="third-panel">
-            <div class="container">
-                <h1 class="display-4">Title</h1>
-                <p>XXX</p>
-            </div>
-        </section>
-        
-        <section id="c" class="third-panel">
-            <div class="container">
-                <h1 class="display-4">Title</h1>
-                <p>XXX</p>
-            </div>
-        </section>
-        
-        <section id="d" class="third-panel">
-            <div class="container">
-                <h1 class="display-4">Title</h1>
-                <p>XXX</p>
-            </div>
-        </section>
-        
-        <section id="e" class="third-panel">
-            <div class="container">
-                <h1 class="display-4">Title</h1>
-                <p>XXX</p>
-            </div>
-        </section>
 
         <footer class="text-white text-center">
             <div class="container">


### PR DESCRIPTION
As raje.html is a stub, redirect to https://rash-framework.github.io/raje-app/ to not break old links

You may also want to try https://help.github.com/articles/redirects-on-github-pages/ but I'm not sure if this works in .html